### PR TITLE
feat: add get named variable command

### DIFF
--- a/Client/Client.cc
+++ b/Client/Client.cc
@@ -52,20 +52,22 @@ jetbridge::Packet* jetbridge::Client::Request(char data[], int timeout) {
 
 void jetbridge::Client::ExecuteCalculatorCode(std::string code) {
   char data[jetbridge::kPacketDataSize] = {};
-  data[0] = jetbridge::kExecuteCalculatorCodeVoid;
+  data[0] = jetbridge::kExecuteCalculatorCode;
   std::memcpy(data + 1, code.c_str(), sizeof(data) - 1);
 
   auto response = this->Request(data);
   delete response;
 }
 
-// TODO: DRY between the two different ExecuteCalculatorCode methods.
-void jetbridge::Client::ExecuteCalculatorCode(std::string code, double* result) {
+double jetbridge::Client::GetNamedVariable(std::string variable_name) {
   char data[jetbridge::kPacketDataSize] = {};
-  data[0] = jetbridge::kExecuteCalculatorCodeDouble;
-  std::memcpy(data + 1, code.c_str(), sizeof(data) - 1);
+  data[0] = jetbridge::kGetNamedVariable;
+  std::memcpy(data + 1, variable_name.c_str(), sizeof(data) - 1);
 
   auto response = this->Request(data);
-  std::memcpy(result, response->data, sizeof(double));
-  delete response;
+
+  double variable_value;
+  // Get the actual value from the response packet.
+  std::memcpy(&variable_value, response->data, sizeof(double));
+  return variable_value;
 }

--- a/Client/Client.cc
+++ b/Client/Client.cc
@@ -1,7 +1,5 @@
 #include "Client.hh"
 
-#include <algorithm>
-
 #include "SimConnect.h"
 
 jetbridge::Client::Client(void* simconnect) {

--- a/Client/Client.cc
+++ b/Client/Client.cc
@@ -1,5 +1,7 @@
 #include "Client.hh"
 
+#include <algorithm>
+
 #include "SimConnect.h"
 
 jetbridge::Client::Client(void* simconnect) {
@@ -16,7 +18,7 @@ jetbridge::Client::Client(void* simconnect) {
                                SIMCONNECT_CLIENT_DATA_PERIOD_ON_SET, SIMCONNECT_CLIENT_DATA_REQUEST_FLAG_CHANGED);
 }
 
-void jetbridge::Client::handle_received_client_data_event(void* event) {
+void jetbridge::Client::HandleReceivedClientDataEvent(void* event) {
   // We're going to actually copy the packet. This allows us to return a pointer instead of copying it around.
   // Of course, it is the user's responsibility to delete this when done.
   auto e = static_cast<SIMCONNECT_RECV_CLIENT_DATA*>(event);
@@ -32,7 +34,7 @@ void jetbridge::Client::handle_received_client_data_event(void* event) {
   requests[packet->id]->set_value(packet);
 }
 
-jetbridge::Packet* jetbridge::Client::request(char data[], int timeout) {
+jetbridge::Packet* jetbridge::Client::Request(char data[], int timeout) {
   // Prepare the outgoing packet.
   Packet* packet = new Packet(data);
 
@@ -48,4 +50,24 @@ jetbridge::Packet* jetbridge::Client::request(char data[], int timeout) {
 
   if (status != std::future_status::ready) return 0;
   return future.get();
+}
+
+void jetbridge::Client::ExecuteCalculatorCode(std::string code) {
+  char data[jetbridge::kPacketDataSize] = {};
+  data[0] = jetbridge::kExecuteCalculatorCodeVoid;
+  std::memcpy(data + 1, code.c_str(), sizeof(data) - 1);
+
+  auto response = this->Request(data);
+  delete response;
+}
+
+// TODO: DRY between the two different ExecuteCalculatorCode methods.
+void jetbridge::Client::ExecuteCalculatorCode(std::string code, double* result) {
+  char data[jetbridge::kPacketDataSize] = {};
+  data[0] = jetbridge::kExecuteCalculatorCodeDouble;
+  std::memcpy(data + 1, code.c_str(), sizeof(data) - 1);
+
+  auto response = this->Request(data);
+  std::memcpy(result, response->data, sizeof(double));
+  delete response;
 }

--- a/Client/Client.cc
+++ b/Client/Client.cc
@@ -46,7 +46,7 @@ jetbridge::Packet* jetbridge::Client::Request(char data[], int timeout) {
   auto future = promise->get_future();
   auto status = future.wait_for(std::chrono::milliseconds(timeout));
 
-  if (status != std::future_status::ready) return 0;
+  if (status != std::future_status::ready) return nullptr;
   return future.get();
 }
 
@@ -65,9 +65,10 @@ double jetbridge::Client::GetNamedVariable(std::string variable_name) {
   std::memcpy(data + 1, variable_name.c_str(), sizeof(data) - 1);
 
   auto response = this->Request(data);
-
   double variable_value;
   // Get the actual value from the response packet.
   std::memcpy(&variable_value, response->data, sizeof(double));
+
+  delete response;
   return variable_value;
 }

--- a/Client/Client.hh
+++ b/Client/Client.hh
@@ -1,5 +1,4 @@
 #pragma once
-#define NOMINMAX
 #include <Windows.h>
 
 #include <future>

--- a/Client/Client.hh
+++ b/Client/Client.hh
@@ -1,5 +1,5 @@
 #pragma once
-
+#define NOMINMAX
 #include <Windows.h>
 
 #include <future>
@@ -9,6 +9,12 @@
 
 namespace jetbridge {
 
+enum CalculatorCodeResultType {
+  kFloat,    // double
+  kInteger,  // int
+  kString,   // char*
+};
+
 class Client {
  private:
   void* simconnect = 0;
@@ -16,8 +22,11 @@ class Client {
 
  public:
   Client(void* simconnect);
-  void handle_received_client_data_event(void* event);
-  Packet* request(char data[], int timeout = 1000);
+  void HandleReceivedClientDataEvent(void* event);
+  Packet* Request(char data[], int timeout = 1000);
+
+  void ExecuteCalculatorCode(std::string code);
+  void ExecuteCalculatorCode(std::string code, double* result);
 };
 
 }  // namespace jetbridge

--- a/Client/Client.hh
+++ b/Client/Client.hh
@@ -8,12 +8,6 @@
 
 namespace jetbridge {
 
-enum CalculatorCodeResultType {
-  kFloat,    // double
-  kInteger,  // int
-  kString,   // char*
-};
-
 class Client {
  private:
   void* simconnect = 0;
@@ -25,7 +19,7 @@ class Client {
   Packet* Request(char data[], int timeout = 1000);
 
   void ExecuteCalculatorCode(std::string code);
-  void ExecuteCalculatorCode(std::string code, double* result);
+  double GetNamedVariable(std::string variable_name);
 };
 
 }  // namespace jetbridge

--- a/Client/Client.vcxproj
+++ b/Client/Client.vcxproj
@@ -130,6 +130,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -145,6 +146,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/Example/Example.cc
+++ b/Example/Example.cc
@@ -41,13 +41,19 @@ int main() {
   std::thread loopThread(loop);
 
   while (!QUIT_SIGNAL_RECEIVED) {
-    std::string code;
-    std::cin >> code;
+    std::string verb, args;
+    std::cin >> verb;
+    std::getline(std::cin, args);
+    // Remove the extra space.
+    args.erase(0, 1);
 
-    double* result = new double;
-    client->ExecuteCalculatorCode(code, result);
-    std::cout << *result << std::endl;
-    delete result;
+    if (verb == "exe") {
+      client->ExecuteCalculatorCode(args);
+      std::cout << args << std::endl;
+    } else if (verb == "get") {
+      double value = client->GetNamedVariable(args);
+      std::cout << value << std::endl;
+    }
   }
 
   // We'll block until the loop thread exits too.

--- a/Example/Example.cc
+++ b/Example/Example.cc
@@ -19,7 +19,7 @@ void CALLBACK MyDispatchProc(SIMCONNECT_RECV* pData, DWORD cbData, void* pContex
 
     case SIMCONNECT_RECV_ID_CLIENT_DATA: {
       auto e = static_cast<SIMCONNECT_RECV_CLIENT_DATA*>(pData);
-      if (e->dwRequestID == jetbridge::kDownlinkRequest) client->handle_received_client_data_event(e);
+      if (e->dwRequestID == jetbridge::kDownlinkRequest) client->HandleReceivedClientDataEvent(e);
       break;
     }
   }
@@ -41,11 +41,13 @@ int main() {
   std::thread loopThread(loop);
 
   while (!QUIT_SIGNAL_RECEIVED) {
-    char code[jetbridge::kPacketDataSize] = {};
-    code[0] = 'x';
-    std::cin.getline(code + 1, sizeof(code) - 1);
-    auto response = client->request(code);
-    delete response;  // response is a Packet* - be sure to delete when no longer needed.
+    std::string code;
+    std::cin >> code;
+
+    double* result = new double;
+    client->ExecuteCalculatorCode(code, result);
+    std::cout << *result << std::endl;
+    delete result;
   }
 
   // We'll block until the loop thread exits too.

--- a/Example/Example.vcxproj
+++ b/Example/Example.vcxproj
@@ -72,6 +72,9 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link />
+    <ClCompile>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+    </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Module/Module.cc
+++ b/Module/Module.cc
@@ -37,10 +37,14 @@ void CALLBACK HandleSimconnectMessage(SIMCONNECT_RECV* pData, DWORD cbData, void
 
     case jetbridge::kGetNamedVariable: {
       int named_variable = check_named_variable(payload.c_str());
+      // Do not send a reply packet if the variable was not found.
+      if (named_variable == -1) return;
+
       double variable_value = get_named_variable_value(named_variable);
       // Copy the result float into the response packet's data member variable.
       // We're assuming that sizeof(double) < sizeof(packet).
       std::memcpy(response->data, &variable_value, sizeof(double));
+
       break;
     }
 

--- a/Module/Module.cc
+++ b/Module/Module.cc
@@ -30,17 +30,17 @@ void CALLBACK HandleSimconnectMessage(SIMCONNECT_RECV* pData, DWORD cbData, void
   std::string payload = (char*)(packet->data + 1);
 
   switch (opcode) {
-    case jetbridge::kExecuteCalculatorCodeVoid: {
+    case jetbridge::kExecuteCalculatorCode: {
       execute_calculator_code(payload.c_str(), 0, 0, 0);
       break;
     }
 
-    case jetbridge::kExecuteCalculatorCodeDouble: {
-      double* calculator_result = new double;
-      execute_calculator_code(payload.c_str(), calculator_result, 0, 0);
-      // Copy the calculator_result float into the response packet's data member variable.
+    case jetbridge::kGetNamedVariable: {
+      int named_variable = check_named_variable(payload.c_str());
+      double variable_value = get_named_variable_value(named_variable);
+      // Copy the result float into the response packet's data member variable.
       // We're assuming that sizeof(double) < sizeof(packet).
-      std::memcpy(response->data, calculator_result, sizeof(double));
+      std::memcpy(response->data, &variable_value, sizeof(double));
       break;
     }
 

--- a/Module/Module.hh
+++ b/Module/Module.hh
@@ -10,5 +10,5 @@
 #define __restrict__
 #endif
 
-const char* kModuleVersion = "0.1.0";
+const char* kModuleVersion = "0.2.0";
 const char* kSimconnectClientName = "Jetbridge";

--- a/Protocol/Protocol.cc
+++ b/Protocol/Protocol.cc
@@ -7,7 +7,8 @@
 jetbridge::Packet::Packet(char data[]) {
   // TODO: better random id generation.
   srand(time(0));
-  this->id = rand();
+  // HACK: static offset avoids collisions.
+  this->id = rand() + (++this->offset);
 
   // Copy the passed data to the packet data
   std::memcpy(this->data, data, sizeof(this->data));

--- a/Protocol/Protocol.hh
+++ b/Protocol/Protocol.hh
@@ -7,17 +7,23 @@ static const char* kPublicDownlinkChannel = "theomessin.jetbridge.downlink";
 static const char* kPublicUplinkChannel = "theomessin.jetbridge.uplink";
 
 class Packet {
+ private:
+  // HACK: static offset avoids collisions.
+  inline static unsigned int offset = 0;
+
  public:
-  int id;
+  int id = 0;
   char data[kPacketDataSize] = {};
+
+  Packet(){};
   Packet(char data[]);
 };
 
-enum ClientDataDefinitions {
+enum ClientDataDefinition {
   kPacketDefinition = 5321,
 };
 
-enum ClientDataAreas {
+enum ClientDataArea {
   kPublicDownlinkArea = 5321,
   kPublicUplinkArea = 5322,
 };
@@ -25,6 +31,11 @@ enum ClientDataAreas {
 enum DataRequest {
   kUplinkRequest = 5321,
   kDownlinkRequest = 5322,
+};
+
+enum Opcode {
+  kExecuteCalculatorCodeVoid = 0,
+  kExecuteCalculatorCodeDouble = 1,
 };
 
 }  // namespace jetbridge

--- a/Protocol/Protocol.hh
+++ b/Protocol/Protocol.hh
@@ -34,8 +34,8 @@ enum DataRequest {
 };
 
 enum Opcode {
-  kExecuteCalculatorCodeVoid = 0,
-  kExecuteCalculatorCodeDouble = 1,
+  kExecuteCalculatorCode = 0,
+  kGetNamedVariable = 1,
 };
 
 }  // namespace jetbridge

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Jetbridge is a simple WebAssembly (WASM) module that allows out-of-process SimConnect modules to act as if they were in-process ones. Specifically, the current development version allows for external modules to dispatch `execute_calculator_code` calls which can be used to read/write `L:` simvars, or even dispatch `H:` events.
+Jetbridge is a simple WebAssembly (WASM) module that allows out-of-process SimConnect modules to act as if they were in-process ones. Specifically, the current development version allows for external modules to dispatch `execute_calculator_code` calls which can be used to write `L:` simvars, or even dispatch `H:` events. Reading the value of local named variables using `get_named_variable` is also supported.
 
 #### How does this even work?
 
@@ -31,7 +31,7 @@ You must first install the Module wasm artifact. You'll have to create a Microso
 
 ![2021-03-05-05-29-01](https://user-images.githubusercontent.com/7229472/110072171-478cfd80-7d75-11eb-859f-200f31bc6c6e.gif)
 
-_Note: the float result of the code is now also displayd in the example application_
+Specifically, use the `exe` verb followed by the your RNN code. You may also use the `get` verb followed by the name of a local variable (without the `L:`) to get the value of an LocalVar. See the [example source code](Example/Example.cc) for more info
 
 #### How to use the C++ Client software development kit
 
@@ -42,14 +42,14 @@ Create a Client instance by passing a SimConnect `HANDLE`:
 client = new jetbridge::Client(simconnect);
 ```
 
-Then you can send some data using `Client->request`:
+Then you can send some data using `Client->Request`:
 
 ```c++
-auto response = client->request((char*)"x2 (>L:A320_Neo_MFD_NAV_MODE_1)");
+auto response = client->Request((char*)"x2 (>L:A320_Neo_MFD_NAV_MODE_1)");
 ```
 
 This example RPN will set (`x` opchar) the `A320_Neo_MFD_NAV_MODE_1` LocalVar to `2`.
-`Client->request` blocks until a response from Jetbridge has been received, or the timeout is reached.
+`Client->Request` blocks until a response from Jetbridge has been received, or the timeout is reached.
 If a response is received, it will return a Packet pointer.
 **Important**: don't forget to delete this when done using it to avoid a memory leak.
 
@@ -57,13 +57,22 @@ If a response is received, it will return a Packet pointer.
 delete response;
 ```
 
-**Important**: You should call the `client->handle_received_client_data_event` function with received data for all `SIMCONNECT_RECV_ID_CLIENT_DATA` events where the RequestID matches `jetbridge::kDownlinkRequest`. Basically, add something along these lines to your `MyDispatchProc`:
+**Important**: You should call the `client->HandleReceivedClientDataEvent` function with received data for all `SIMCONNECT_RECV_ID_CLIENT_DATA` events where the RequestID matches `jetbridge::kDownlinkRequest`. Basically, add something along these lines to your `MyDispatchProc`:
 
 ```c++
 case SIMCONNECT_RECV_ID_CLIENT_DATA:
   auto e = static_cast<SIMCONNECT_RECV_CLIENT_DATA*>(pData);
-  if (e->dwRequestID == jetbridge::kDownlinkRequest) client->handle_received_client_data_event(e);
+  if (e->dwRequestID == jetbridge::kDownlinkRequest) client->HandleReceivedClientDataEvent(e);
   break;
+```
+
+There are also two helper methods to send packets to (1) ExecuteCalculatorCode, and (2) GetNamedVariable:
+
+```c++
+// Execute the given RPN code:
+client->ExecuteCalculatorCode("2 (>L:A320_Neo_MFD_NAV_MODE_1)");
+// Get the value of a local named variable:
+double value = client->GetNamedVariable("A320_Neo_MFD_NAV_MODE_1");
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You must first install the Module wasm artifact. You'll have to create a Microso
 
 ![2021-03-05-05-29-01](https://user-images.githubusercontent.com/7229472/110072171-478cfd80-7d75-11eb-859f-200f31bc6c6e.gif)
 
+_Note: the float result of the code is now also displayd in the example application_
+
 #### How to use the C++ Client software development kit
 
 Make sure you've correctly imported the static library (header files need to be accessible, .lib file needs to be available to the Linker).

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ case SIMCONNECT_RECV_ID_CLIENT_DATA:
   break;
 ```
 
-There are also two helper methods to send packets to (1) ExecuteCalculatorCode, and (2) GetNamedVariable:
+There are also two helper methods to send packets to (1) `ExecuteCalculatorCode`, and (2) `GetNamedVariable`:
 
 ```c++
 // Execute the given RPN code:


### PR DESCRIPTION
The new `client->ExecuteCalculatorCode` methods wrap the necessary `client->Request` calls to run `execute_calculator_code` and potentially get the result as a `double` (FLOAT64). For example:

```cpp
auto result = new double;
client->ExecuteCalculatorCode("(L:A32NX_RMP_L_VHF2_STANDBY_FREQUENCY)", result);
std::cout << result << std::endl;
delete result;  // don't forget to do this!
```

I am not entirely happy with the current interface, however. I'd much prefer to have something like this:
```cpp
auto result = client->ExecuteCalculatorCodeDouble("(L:A32NX_RMP_L_VHF2_STANDBY_FREQUENCY)");
std::cout << result << std::endl;
```

I just really hate having to add the return type to the method's name. This is because the return type would the only difference between overloads, and this is not allowed. At least the first method can be overloaded with different result pointer types (e.g. `double*` or `int*` or `char*`) to allow for the different ways to call `execute_calculator_code`. Maybe I'm just overthinking this...